### PR TITLE
fix/9 add CIF_STORE_NODES env variable to cif.env for systemd service…

### DIFF
--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -9,3 +9,6 @@
 
 - name: modify etc/default/cif with CIF_ES_NODES
   lineinfile: dest=/etc/default/cif line='export CIF_STORE_NODES={{ elasticsearch_nodes }}'
+
+- name: modify etc/cif.env with CIF_ES_NODES
+  lineinfile: dest=/etc/cif.env line='CIF_STORE_NODES={{ elasticsearch_nodes }}'


### PR DESCRIPTION
This was the change I tested based on your guidance.  

I only made changes to the ubuntu16 setup as I believe that's the only one using systemd services from the cif.env file.
