### PR TITLE
Added DOCKER_BUILD condition check, to skip firewall for docker

### DIFF
--- a/ubuntu16/tasks/main.yml
+++ b/ubuntu16/tasks/main.yml
@@ -4,6 +4,7 @@
   when: ansible_distribution_version | version_compare('16.04', '<')
 
 - include_tasks: firewall.yml
+  when: DOCKER_BUILD is defined and DOCKER_BUILD != ""
   tags: firewall
 
 - include_tasks: deps.yml


### PR DESCRIPTION
Added DOCKER_BUILD condition check, to skip anything that starts a service/interacts with systemd. In this case, this is related to the firewall, which is not present on docker images. It assumed that DOCKER_BUILD exists, and it's not empty -- ideally 'DOCKER_BUILD=yes'