### PR TITLE
added DOCKER_BUILD env variable to ansible global vars

### DIFF
--- a/global_vars.yml
+++ b/global_vars.yml
@@ -4,3 +4,4 @@ cif_build_sdist: "{{ lookup('env', 'CIF_ANSIBLE_SDIST') | default() }}"
 router_store_nodes: "{{ lookup('env','CIF_ANSIBLE_ES_NODES')|default('localhost:9200', true) }}"
 cif_version: '3.0.0rc1'
 es_version: "5.4.6"
+DOCKER_BUILD: "{{ lookup('env', 'DOCKER_BUILD') }}"


### PR DESCRIPTION
When building in Docker, setting the DOCKER_BUILD variable causes ansible to determine that it should skip execution of certain tasks, but the variable  is not translated from the environment variable that would be set via the Dockerfile.

Adding a line in the global_vars.yml file to set the ansible variable from the value of the environment variable connects these dots.