### PR TITLE
Docker flags added + a fix for the version check

### DIFF
--- a/ubuntu16/tasks/main.yml
+++ b/ubuntu16/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Check for version 16.04"
   fail: msg="Must be version 16.04 or higher"
-  when: ansible_distribution_version | version_compare('16.04', '<')
+  when: ansible_distribution_version | version_compare('16.04', '>=')
 
 - include_tasks: firewall.yml
   when: DOCKER_BUILD is defined and DOCKER_BUILD != ""

--- a/ubuntu16/tasks/main.yml
+++ b/ubuntu16/tasks/main.yml
@@ -4,6 +4,7 @@
   when: ansible_distribution_version | version_compare('16.04', '<')
 
 - include_tasks: firewall.yml
+  when: DOCKER_BUILD is defined and DOCKER_BUILD != ""
   tags: firewall
 
 - include_tasks: deps.yml


### PR DESCRIPTION
Added:
* Docker flags around the things that docker cannot process - ie: firewall, systemd, etc.

Fixed:
* Check for ubuntu version. Comment and message said "16.04 or higher", but the check was actually checking for "lower than 16.04 -- and this was causing a problem"
(see an ex here: http://docs.ansible.com/ansible/latest/user_guide/playbooks_tests.html#version-comparison)