### PR TITLE
skip nginx restart when DOCKER_BUILD is set

### DIFF
--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -33,3 +33,4 @@
 
 - name: restart nginx
   service: name=nginx state=restarted daemon_reload=yes enabled=yes
+  when: DOCKER_BUILD is undefined or DOCKER_BUILD == 'no'


### PR DESCRIPTION
Added ansible logic to skip nginx restart when DOCKER_BUILD is set

This will only affect Docker builds