### PR TITLE
Update es_version consistently to 5.6.13

### DIFF
--- a/centos7/site.yml
+++ b/centos7/site.yml
@@ -52,7 +52,7 @@
           node.data: true,
           node.master: true,
         },
-        es_version: "5.6.4",
+        es_version: "5.6.13",
         es_instance_name: 'cif',
         when: router_store_store is defined and router_store_store == 'elasticsearch'
       }

--- a/global_vars.yml
+++ b/global_vars.yml
@@ -3,5 +3,5 @@ CIF_ES: "{{ lookup('env', 'CIF_ANSIBLE_ES') }}"
 cif_build_sdist: "{{ lookup('env', 'CIF_ANSIBLE_SDIST') | default() }}"
 router_store_nodes: "{{ lookup('env','CIF_ANSIBLE_ES_NODES')|default('localhost:9200', true) }}"
 cif_version: '3.0.0rc6'
-es_version: "5.4.6"
+es_version: "5.6.13"
 DOCKER_BUILD: "{{ lookup('env', 'DOCKER_BUILD') }}"

--- a/ubuntu16/site.yml
+++ b/ubuntu16/site.yml
@@ -46,7 +46,7 @@
           node.data: true,
           node.master: true,
         },
-        es_version: "5.6.4",
+        es_version: "5.6.13",
         es_instance_name: 'cif',
         when: router_store_store is defined and router_store_store == 'elasticsearch'
       }


### PR DESCRIPTION
Unsure why global var is not used in os specific site.yml, but updates all instances to 5.6.13